### PR TITLE
Implementation of TIP parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 project/target
 target/
 build.properties
+
+.bloop
+.metals
+.vscode
+project

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.5.9"
+runner.dialect = scala3

--- a/build.sbt
+++ b/build.sbt
@@ -11,3 +11,4 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest-featurespec" % "3.2.15" % "test"
 
 libraryDependencies += "org.typelevel" %% "paiges-core" % "0.4.2"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.2.0"

--- a/main-file.tip
+++ b/main-file.tip
@@ -1,0 +1,15 @@
+name () {
+    d = {ha:3};
+    *y.b.a.a = 3;
+    (*dsa).y=8;
+    return 0;
+}
+
+main (a, b) {
+    output name(0, 3*5);
+    output a(0, 3*5);
+    *sla = 8;
+    dois = &sla;
+    tres = (**dois) + 2;
+    return 3;
+}

--- a/src/main/scala/br/unb/cic/tip/Parser.scala
+++ b/src/main/scala/br/unb/cic/tip/Parser.scala
@@ -1,0 +1,189 @@
+package br.unb.cic.tip
+
+import java.nio.file.Paths
+import scala.io.Source
+
+import br.unb.cic.tip.Stmt.*
+import br.unb.cic.tip.Expression.*
+
+import scala.util.parsing.combinator._
+import scala.util.parsing.input.Positional
+
+class BasicParser extends RegexParsers {
+  def id: Parser[Id] = """[a-zA-Z]+""".r
+  def int: Parser[Int] = """-?[0-9]+""".r ^^ { (s) => Integer(s) }
+}
+
+/* Exp → Int
+ *     | Id
+ *     | input
+ *     | null
+ *     | & Id
+ *     | Exp + Exp | Exp - Exp | Exp * Exp | Exp / Exp | Exp > Exp | Exp == Exp
+ *     | ( Exp )
+ *     | Id ( Exp,. . .,Exp )
+ *     | Exp ( Exp , . . ., Exp )
+ *     | alloc Exp
+ *     | * Exp
+ *     | { Id : Exp , . . ., Id : Exp }
+ *     | Exp . Id
+ */
+class ExpressionParser extends BasicParser {
+
+  def prio3Expression: Parser[Expression] = "input" ^^^ InputExp
+    | "alloc" ~> expression ^^ AllocExp.apply
+    | "&" ~> id ^^ LocationExp.apply
+    | "*" ~> expression ^^ LoadExp.apply
+    | "null" ^^^ NullExp
+    | id ^^ VariableExp.apply
+    | int ^^ ConstExp.apply
+    | recordCreation
+    | "(" ~> expression <~ ")" ^^ BracketExp.apply
+
+  def operations: Parser[String] = """[+\-*/>]|(==)""".r
+
+  def prio2ExpressionOperation: Parser[Expression => Expression] =
+    operations ~ commit(expression)
+      ^^ {
+        case "+" ~ exp  => AddExp(_, exp)
+        case "-" ~ exp  => SubExp(_, exp)
+        case "*" ~ exp  => MultiExp(_, exp)
+        case "/" ~ exp  => DivExp(_, exp)
+        case ">" ~ exp  => GTExp(_, exp)
+        case "==" ~ exp => EqExp(_, exp)
+        case _          => throw new RuntimeException("Failure in parsing")
+      }
+      | "." ~> commit(id) ^^ { id => FieldAccess(_, id) }
+      | arguments ^^ { case args => FunctionCallExp(_, args) }
+
+  def prio2Expression: Parser[Expression] =
+    prio3Expression ~ rep(prio2ExpressionOperation) ^^ { case exp ~ list =>
+      list.foldLeft(exp)((exp, exp2) => exp2(exp))
+    }
+
+  def arguments: Parser[List[Expression]] =
+    "(" ~> opt(expression) <~ ")"
+      ^^ {
+        case None      => Nil
+        case Some(arg) => List(arg)
+      }
+      | "(" ~> commit(expression ~ rep("," ~> commit(expression)) <~ ")")
+      ^^ mkList
+
+  def field: Parser[Field] =
+    id ~ (":" ~> expression) ^^ { case id ~ exp => (id, exp) }
+  def recordCreation: Parser[RecordExp] =
+    "{" ~> rep1sep(field, ",") <~ "}" ^^ { case a => RecordExp(a) }
+
+  def expression: Parser[Expression] = prio2Expression
+}
+
+object ExpressionParser extends ExpressionParser {
+  def parse(input: String): ParseResult[Expression] = {
+    parse(expression, input)
+  }
+}
+
+class StatementParser extends ExpressionParser {
+  def condition: Parser[Expression] = "(" ~> expression <~ ")"
+  def block: Parser[Stmt] = "{" ~> statement <~ "}"
+  def assignment: Parser[Expression] = "=" ~> expression <~ ";"
+  def elseBlock: Parser[Option[Stmt]] =
+    "else" ~> commit(block) ^^ Some.apply
+      | success(None)
+
+  def singleStmt: Parser[Stmt] = failure("Helper to fix formatting")
+    | "*" ~> commit(expression ~ assignment)
+    ^^ { case ponterExp ~ newValueExp => StoreStmt(ponterExp, newValueExp) }
+    | "(" ~> commit(
+      ("*" ~> expression <~ ")") ~ ("." ~> id) ~ assignment
+    )
+    ^^ { case ponterExp ~ id ~ newValueExp =>
+      RecordStoreStmt(ponterExp, id, newValueExp)
+    }
+    | "output" ~> expression <~ ";" ^^ OutputStmt.apply
+    | "if" ~> commit(condition ~ block ~ elseBlock)
+    ^^ { case exp1 ~ thenStmt ~ elseStmt =>
+      IfElseStmt(exp1, thenStmt, elseStmt)
+    }
+    | "while" ~> commit(condition ~ block)
+    ^^ { case exp1 ~ thenStmt => WhileStmt(exp1, thenStmt) }
+    | id ~ ("." ~> commit(id ~ assignment))
+    ^^ { case name ~ (field ~ exp) => RecordAssignmentStmt(name, field, exp) }
+    | id ~ commit(assignment)
+    ^^ { case id ~ exp => AssignmentStmt(id, exp) }
+
+  def returnGuardedStmt =
+    singleStmt - "return"
+
+  def statement: Parser[Stmt] =
+    returnGuardedStmt ~ rep(returnGuardedStmt) ^^ { case stmt ~ stmtList =>
+      stmtList.reverse match {
+        case Nil => stmt
+        case lastStmt :: restOfStmts =>
+          SequenceStmt(
+            stmt,
+            restOfStmts.foldLeft(lastStmt)((stmt1, stmt2) =>
+              SequenceStmt(stmt2, stmt1)
+            )
+          )
+      }
+    }
+      | success(NopStmt)
+}
+
+object StatementParser extends StatementParser {
+  def parse(input: String): ParseResult[Stmt] = {
+    parse(statement, input)
+  }
+}
+
+class FunctionParser extends StatementParser {
+  def functionVariables: Parser[List[Id]] =
+    "var" ~> commit(rep1sep(id, ",") <~ ";") ^^ { case value =>
+      value
+    }
+      | success(Nil)
+
+  def function: Parser[FunDecl] = failure("Helper to fix formatting")
+    | id
+    ~ ("(" ~> repsep(id, ",") <~ ")")
+    ~ ("{" ~> functionVariables
+      ~ statement
+      ~ ("return" ~> expression <~ ";") <~ "}")
+    ^^ { case name ~ params ~ (vars ~ funcStmt ~ returnExp) =>
+      FunDecl(name, params, vars, funcStmt, returnExp)
+    }
+}
+
+object FunctionParser extends FunctionParser {
+  def parse(input: String): ParseResult[FunDecl] = {
+    parse(function, input)
+  }
+}
+
+object TipParser extends FunctionParser {
+  def program: Parser[List[FunDecl]] =
+    phrase(rep(function))
+
+  def parse(input: String): ParseResult[List[FunDecl]] = {
+    parse(program, input)
+  }
+}
+
+def getFileContents(fileName: String) =
+  try {
+    Source.fromFile(fileName).mkString
+  } catch {
+    case _ =>
+      println(
+        "Can't find file '" + fileName +
+          "'. Using the first argument as source code instead"
+      )
+      fileName
+  }
+
+@main def main(firstString: String, others: String*) =
+  val fileContents = getFileContents(firstString)
+  println("============================")
+  println(TipParser.parse(fileContents))

--- a/src/main/scala/br/unb/cic/tip/Syntax.scala
+++ b/src/main/scala/br/unb/cic/tip/Syntax.scala
@@ -37,9 +37,8 @@ enum Expression:
   case GTExp(left: Expression, right: Expression) extends Expression // Exp > Exp
   case BracketExp(exp: Expression) extends Expression // (Exp)
 
-  // function-call expressions
-  case DirectFunctionCallExp(name: Id, args: List[Expression]) extends Expression // Id ( Exp,. . . ,Exp )
-  case IndirectFunctionCallExp(exp: Expression, args: List[Expression]) extends Expression // Exp ( Exp , . . . , Exp )
+  // function-call expression
+  case FunctionCallExp(exp: Expression, args: List[Expression]) extends Expression
 
   // pointer-based expressions
   case AllocExp(exp: Expression) extends Expression // alloc Exp
@@ -60,6 +59,9 @@ enum Stmt:
   case SequenceStmt(s1: Stmt, s2: Stmt) extends Stmt // Stmt Stmt
   case StoreStmt(exp1: Expression, exp2: Expression) extends Stmt // *Exp = Exp
   case OutputStmt(exp: Expression) extends Stmt // output Exp
+  case RecordAssignmentStmt(name: Id, field: Id, exp: Expression) extends Stmt // Id.Id = Exp;
+  case RecordStoreStmt(exp1: Expression, id: Id, exp2: Expression) // (*Exp).Id = Exp;
+  case NopStmt extends Stmt // nop
 
 /** Node Types */
 enum Node:

--- a/src/test/scala/br/unb/cic/tip/parser/ExpressionParserTest.scala
+++ b/src/test/scala/br/unb/cic/tip/parser/ExpressionParserTest.scala
@@ -1,0 +1,327 @@
+package br.unb.cic.tip.parser
+
+import org.scalatest.funsuite.AnyFunSuite
+import br.unb.cic.tip.*
+
+import br.unb.cic.tip.Stmt.*
+import br.unb.cic.tip.Expression.*
+
+/* Exp → Int
+ *     | Id
+ *     | Exp + Exp | Exp - Exp | Exp * Exp | Exp / Exp | Exp > Exp | Exp == Exp
+ *     | ( Exp )
+ *     | input
+ *     | Id ( Exp,. . .,Exp )
+ *     | Exp ( Exp , . . ., Exp )
+ *     | alloc Exp
+ *     | & Id
+ *     | * Exp
+ *     | null.
+ *     | { Id : Exp , . . ., Id : Exp }
+ *     | Exp . Id
+ */
+class ExpressionParserTest extends AnyFunSuite {
+
+  test("should fail to parse an empty string") {
+    val result = ExpressionParser.parse("")
+
+    assert(result.successful == false)
+  }
+
+  test("should parse a positive number") {
+    val result = ExpressionParser.parse("123456")
+
+    assert(result.get == ConstExp(123456))
+  }
+
+  test("should parse a negative number") {
+    val result = ExpressionParser.parse("-7890")
+
+    assert(result.get == ConstExp(-7890))
+  }
+
+  test("should parse variable expression") {
+    val result = ExpressionParser.parse("variable")
+
+    assert(result.get == VariableExp("variable"))
+  }
+
+  test("should parse addition operation") {
+    val result = ExpressionParser.parse("8 + variable")
+
+    assert(result.get == AddExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse subtraction operation") {
+    val result = ExpressionParser.parse("8 - variable")
+
+    assert(result.get == SubExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse multiplication operation") {
+    val result = ExpressionParser.parse("8 * variable")
+
+    assert(result.get == MultiExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse division operation") {
+    val result = ExpressionParser.parse("8 / variable")
+
+    assert(result.get == DivExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse greater than operation") {
+    val result = ExpressionParser.parse("8 > variable")
+
+    assert(result.get == GTExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse equals operation") {
+    val result = ExpressionParser.parse("8 == variable")
+
+    assert(result.get == EqExp(ConstExp(8), VariableExp("variable")))
+  }
+
+  test("should parse equation with varibale and brackets") {
+    val result = ExpressionParser.parse("(8) - (variable * 3)")
+
+    assert(
+      result.get ==
+        SubExp(
+          BracketExp(ConstExp(8)),
+          BracketExp(MultiExp(VariableExp("variable"), ConstExp(3)))
+        )
+    )
+  }
+
+  test("should parse equation with complex expression") {
+    val result = ExpressionParser.parse("8 + {a: 3}.b(5) * 2")
+
+    assert(
+      result.get == AddExp(
+        ConstExp(8),
+        MultiExp(
+          FunctionCallExp(
+            FieldAccess(RecordExp(List(("a", ConstExp(3)))), "b"),
+            List(ConstExp(5))
+          ),
+          ConstExp(2)
+        )
+      )
+    )
+  }
+
+  test("should parse input expression") {
+    val result = ExpressionParser.parse("input")
+
+    assert(result.get == InputExp)
+  }
+
+  test("should parse allocation expression") {
+    val result = ExpressionParser.parse("alloc 3")
+
+    assert(result.get == AllocExp(ConstExp(3)))
+  }
+
+  test("should parse location expression") {
+    val result = ExpressionParser.parse("& variable")
+
+    assert(result.get == LocationExp("variable"))
+
+  }
+
+  test("should parse load expression") {
+    val result = ExpressionParser.parse("* (variable + 1)")
+
+    assert(
+      result.get ==
+        LoadExp(
+          BracketExp(AddExp(VariableExp("variable"), ConstExp(1)))
+        )
+    )
+  }
+
+  test("should parse null expression") {
+    val result = ExpressionParser.parse("null")
+
+    assert(result.get == NullExp)
+  }
+
+  test("should parse record expression") {
+    val result = ExpressionParser.parse("{a : 3}")
+
+    assert(result.get == RecordExp(List(("a", ConstExp(3)))))
+  }
+
+  test("should parse complex record expression") {
+    val result = ExpressionParser.parse("{a : 3, subRecord: ({b: 65})}")
+
+    assert(
+      result.get == RecordExp(
+        List(
+          ("a", ConstExp(3)),
+          ("subRecord", BracketExp(RecordExp(List(("b", ConstExp(65))))))
+        )
+      )
+    )
+  }
+
+  test("should parse field access") {
+    val result = ExpressionParser.parse("variable.name")
+
+    assert(result.get == FieldAccess(VariableExp("variable"), "name"))
+  }
+
+  test("should parse field access on field access") {
+    val result = ExpressionParser.parse("a.b.c")
+
+    assert(result.get == FieldAccess(FieldAccess(VariableExp("a"), "b"), "c"))
+  }
+
+  test("should parse complex field access") {
+    val result = ExpressionParser.parse("{a : 4}.a + b.c")
+
+    assert(
+      result.get ==
+        AddExp(
+          FieldAccess(RecordExp(List(("a", ConstExp(4)))), "a"),
+          FieldAccess(VariableExp("b"), "c")
+        )
+    )
+  }
+
+  test("should parse direct function call no args") {
+    val result = ExpressionParser.parse("foo()")
+
+    assert(result.get == FunctionCallExp(VariableExp("foo"), Nil))
+  }
+
+  test("failure: should parse direct function call with args") {
+    val result = ExpressionParser.parse("foo(1, b, {j : 0})")
+
+    assert(
+      result.get == FunctionCallExp(
+        VariableExp("foo"),
+        List(ConstExp(1), VariableExp("b"), RecordExp(List(("j", ConstExp(0)))))
+      )
+    )
+  }
+
+  test("should parse indirect function call no args") {
+    val result = ExpressionParser.parse("foo.a()")
+
+    assert(
+      result.get == FunctionCallExp(
+        FieldAccess(VariableExp("foo"), "a"),
+        List()
+      )
+    )
+  }
+
+  test("failure: should parse indirect higher order function call") {
+    val result = ExpressionParser.parse("foo()(a)(b, c)")
+
+    assert(
+      result.get == FunctionCallExp(
+        FunctionCallExp(
+          FunctionCallExp(
+            VariableExp("foo"),
+            Nil
+          ),
+          List(VariableExp("a"))
+        ),
+        List(VariableExp("b"), VariableExp("c"))
+      )
+    )
+  }
+
+  test("failure: should parse indirect function call curried with args") {
+    val result = ExpressionParser.parse("foo.a().b(a, b, c)")
+
+    assert(
+      result.get == FunctionCallExp(
+        FieldAccess(
+          FunctionCallExp(
+            FieldAccess(VariableExp("foo"), "a"),
+            Nil
+          ),
+          "b"
+        ),
+        List(VariableExp("a"), VariableExp("b"), VariableExp("c"))
+      )
+    )
+  }
+
+  def failureHelper(input: String) =
+    val result = ExpressionParser.parse(input)
+    try {
+      assert(result.successful == false)
+    } catch {
+      case e => {
+        println("Failure ----------")
+        println(input + ">>>>>>>" + result)
+        throw e
+      }
+    }
+
+  test("should fail on missing id for location") {
+    failureHelper("& ")
+  }
+
+  test("should fail on missing expression for load") {
+    failureHelper("* ")
+  }
+
+  test("should fail on dangling comma") {
+    failureHelper("call(test,)")
+  }
+
+  test("should fail on missing second argument") {
+    failureHelper("call (test, ")
+  }
+
+  test("should fail on missing closing parenthesis") {
+    failureHelper("call (test")
+
+  }
+
+  test("should fail on trailing comma") {
+    failureHelper("call(, test)")
+  }
+
+  test("should fail on missing closing parenthesis without args") {
+    failureHelper("call (")
+  }
+
+  test("should fail on missing closing parenthesis on DirectFunctionCall") {
+    failureHelper("call (test")
+  }
+
+  test("should fail on missing closing parenthesis on IndirectFunctionCall") {
+    failureHelper("a.b (test")
+  }
+
+  test("should fail on missing closing parenthesis on Brackets") {
+    failureHelper("(test")
+  }
+
+  test("should fail on empty record") {
+    failureHelper("{}")
+  }
+
+  test("should fail on empty brackets") {
+    failureHelper("()")
+  }
+
+  test("should fail on missing second operand") {
+    failureHelper("3 + ")
+  }
+
+  test("should fail on value missing on record") {
+    failureHelper("{sla: }")
+  }
+
+  test("should fail on missing id on field access") {
+    failureHelper("{sla: 3} . ")
+  }
+}

--- a/src/test/scala/br/unb/cic/tip/parser/FunctionParserTest.scala.scala
+++ b/src/test/scala/br/unb/cic/tip/parser/FunctionParserTest.scala.scala
@@ -1,0 +1,255 @@
+package br.unb.cic.tip.parser
+
+import org.scalatest.funsuite.AnyFunSuite
+import br.unb.cic.tip.*
+
+import br.unb.cic.tip.Stmt.*
+import br.unb.cic.tip.Expression.*
+
+class FunctionParserTest extends AnyFunSuite {
+  test("should fail to parse empty strings") {
+    val result = FunctionParser.parse("")
+
+    assert(result.successful == false)
+  }
+
+  test("should parse simple function") {
+    val result = FunctionParser.parse("a () { return 0; }")
+
+    assert(result.get == FunDecl("a", List(), List(), NopStmt, ConstExp(0)))
+  }
+
+  test("should parse function with argument") {
+    val result = FunctionParser.parse("a (a) { return 0; }")
+
+    assert(result.get == FunDecl("a", List("a"), List(), NopStmt, ConstExp(0)))
+  }
+
+  test("should parse function with arguments") {
+    val result = FunctionParser.parse("a (a, b, c) { return 0; }")
+
+    assert(
+      result.get == FunDecl(
+        "a",
+        List("a", "b", "c"),
+        List(),
+        NopStmt,
+        ConstExp(0)
+      )
+    )
+  }
+
+  test("should parse function with body") {
+    val input = """
+        a (a, b, c) {
+            i = 3;
+            return 0;
+        }
+    """
+
+    val result = FunctionParser.parse(input)
+
+    assert(
+      result.get == FunDecl(
+        "a",
+        List("a", "b", "c"),
+        List(),
+        AssignmentStmt("i", ConstExp(3)),
+        ConstExp(0)
+      )
+    )
+  }
+
+  test("should parse function with local variable") {
+    val input = """
+        a (a) {
+            var i;
+            return 0;
+        }
+    """
+
+    val result = FunctionParser.parse(input)
+
+    assert(
+      result.get == FunDecl("a", List("a"), List("i"), NopStmt, ConstExp(0))
+    )
+  }
+
+  test("should parse function with local variables") {
+    val input = """
+        a (a) {
+            var i, j, k;
+            return 0;
+        }
+    """
+
+    val result = FunctionParser.parse(input)
+
+    assert(
+      result.get == FunDecl(
+        "a",
+        List("a"),
+        List("i", "j", "k"),
+        NopStmt,
+        ConstExp(0)
+      )
+    )
+  }
+
+  test("should parse complex function") {
+    val input = """
+        fact (n) {
+            var i, ret;
+            i = n;
+            ret = n;
+
+            if(i == 0) {
+                ret = 1;
+            }
+
+            while(i > 1) {
+                ret = ret * i;
+                i = i - 1;
+            }
+
+            return ret;
+        }
+    """
+
+    val result = FunctionParser.parse(input)
+
+    assert(
+      result.get == FunDecl(
+        "fact",
+        List("n"),
+        List("i", "ret"),
+        SequenceStmt(
+          AssignmentStmt("i", VariableExp("n")),
+          SequenceStmt(
+            AssignmentStmt("ret", VariableExp("n")),
+            SequenceStmt(
+              IfElseStmt(
+                EqExp(VariableExp("i"), ConstExp(0)),
+                AssignmentStmt("ret", ConstExp(1)),
+                None
+              ),
+              WhileStmt(
+                GTExp(VariableExp("i"), ConstExp(1)),
+                SequenceStmt(
+                  AssignmentStmt(
+                    "ret",
+                    MultiExp(VariableExp("ret"), VariableExp("i"))
+                  ),
+                  AssignmentStmt("i", SubExp(VariableExp("i"), ConstExp(1)))
+                )
+              )
+            )
+          )
+        ),
+        VariableExp("ret")
+      )
+    )
+  }
+
+  def failureHelper(input: String) =
+    val result = FunctionParser.parse(input)
+    try {
+      assert(result.successful == false)
+    } catch {
+      case e => {
+        println("Failure ----------")
+        println(input + ">>>>>>>" + result)
+        throw e
+      }
+    }
+
+  test("should fail on missing id") {
+    failureHelper("() {}")
+  }
+
+  test("should fail on missing brackets") {
+    failureHelper("foo")
+  }
+
+  test("should fail on missing closing brackets") {
+    failureHelper("foo( {}")
+  }
+
+  test("should fail on missing closing brackets with args") {
+    failureHelper("foo(test {}")
+  }
+
+  test("should fail on missing second argument") {
+    failureHelper("foo(test,) {}")
+  }
+
+  test("should fail on missing first argument") {
+    failureHelper("foo(,test) {}")
+  }
+
+  test("should fail on missing return statement") {
+    val input = """
+        fact (n) {}
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on bad return statement") {
+    val input = """
+        fact (n) {
+          return
+        }
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on missing return semicolon") {
+    val input = """
+        fact (n) {
+          return 0
+        }
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on missing variables on declaration") {
+    val input = """
+        fact (n) {
+          var 
+          return 0;
+        }
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on missing second variable") {
+    val input = """
+        fact (n) {
+          var a,
+          return 0;
+        }
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on missing semicolon on variable declaration") {
+    val input = """
+        fact (n) {
+          var a, b
+          return 0;
+        }
+    """
+    failureHelper(input)
+  }
+
+  test("should fail on failing statement") {
+    val input = """
+        fact (n) {
+          failureStmt
+          return 0;
+        }
+    """
+    failureHelper(input)
+  }
+
+}

--- a/src/test/scala/br/unb/cic/tip/parser/StatementParserTest.scala
+++ b/src/test/scala/br/unb/cic/tip/parser/StatementParserTest.scala
@@ -1,0 +1,237 @@
+package br.unb.cic.tip.parser
+
+import org.scalatest.funsuite.AnyFunSuite
+import br.unb.cic.tip.*
+
+import br.unb.cic.tip.Stmt.*
+import br.unb.cic.tip.Expression.*
+
+class StatementParserTest extends AnyFunSuite {
+  test("should parse empty strings") {
+    val result = StatementParser.parse("")
+
+    assert(result.successful)
+  }
+
+  test("should parse assignments") {
+    val result = StatementParser.parse("v = exp;")
+
+    assert(result.get == AssignmentStmt("v", VariableExp("exp")))
+  }
+
+  test("should parse output statements") {
+    val result = StatementParser.parse("output exp ;")
+
+    assert(result.get == OutputStmt(VariableExp("exp")))
+  }
+
+  test("should parse statement sequences") {
+    val result = StatementParser.parse("output exp ; x = 3;")
+
+    assert(
+      result.get == SequenceStmt(
+        OutputStmt(VariableExp("exp")),
+        AssignmentStmt("x", ConstExp(3))
+      )
+    )
+  }
+
+  test("should parse ifs") {
+    val input = """
+      if (v) {
+        x = 0;
+      }
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == IfElseStmt(
+        VariableExp("v"),
+        AssignmentStmt("x", ConstExp(0)),
+        None
+      )
+    )
+  }
+
+  test("should parse if with else") {
+    val input = """
+      if (v) {
+        x = 0;
+      } else {
+        output 8;
+      }
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == IfElseStmt(
+        VariableExp("v"),
+        AssignmentStmt("x", ConstExp(0)),
+        Some(OutputStmt(ConstExp(8)))
+      )
+    )
+  }
+
+  test("should parse while") {
+    val input = """
+      while(8 == 5) {
+        id = v + 7;
+      }
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == WhileStmt(
+        EqExp(ConstExp(8), ConstExp(5)),
+        AssignmentStmt("id", AddExp(VariableExp("v"), ConstExp(7)))
+      )
+    )
+  }
+
+  test("should parse store") {
+    val input = """
+      * v = 5;
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == StoreStmt(VariableExp("v"), ConstExp(5))
+    )
+  }
+
+  test("should parse store with expression") {
+    val input = """
+      *val.b  = 5;
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == StoreStmt(FieldAccess(VariableExp("val"), "b"), ConstExp(5))
+    )
+  }
+
+  test("should parse record assignmment") {
+    val input = """
+      id . a = 8;
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == RecordAssignmentStmt("id", "a", ConstExp(8))
+    )
+  }
+
+  test("should parse record store") {
+    val input = """
+      (*val).b  = 6;
+    """
+
+    val result = StatementParser.parse(input)
+
+    assert(
+      result.get == RecordStoreStmt(VariableExp("val"), "b", ConstExp(6))
+    )
+  }
+
+  def failureHelper(input: String) =
+    val result = StatementParser.parse(input)
+    try {
+      assert(result.successful == false)
+    } catch {
+      case e => {
+        println("Failure ----------")
+        println(input + ">>>>>>>" + result)
+        throw e
+      }
+    }
+
+  test("should fail on missing if condition") {
+    failureHelper("if() {}")
+  }
+
+  test("should fail on missing if parenthesis") {
+    failureHelper("if ")
+  }
+
+  test("should fail on missing if closing parenthesis") {
+    failureHelper("if ( ")
+  }
+
+  test("should fail on missing if brackets") {
+    failureHelper("if()")
+  }
+
+  test("should fail on missing if closing brackets") {
+    failureHelper("if(0) {")
+  }
+
+  test("should fail on missing else brackets") {
+    failureHelper("if(0) {} else ")
+  }
+
+  test("should fail on missing else closing brackets") {
+    failureHelper("if(0) {} else {")
+  }
+
+  test("should fail on missing while condition") {
+    failureHelper("while() {}")
+  }
+
+  test("should fail on missing while parenthesis") {
+    failureHelper("while")
+  }
+
+  test("should fail on missing while closing parenthesis") {
+    failureHelper("while(")
+  }
+
+  test("should fail on missing while brackets") {
+    failureHelper("while(0)")
+  }
+
+  test("should fail on missing while closing brackets") {
+    failureHelper("while(0) {")
+  }
+
+  test("should fail on missing expression in assignment") {
+    failureHelper("e = ;")
+  }
+
+  test("should fail on asterisc only store") {
+    failureHelper("* ")
+  }
+
+  test("should fail on missing first expression in store") {
+    failureHelper("* = 3;")
+  }
+
+  test("should fail on missing second expression in store") {
+    failureHelper("* e = ;")
+  }
+
+  test("should fail on missing second id in record assignment") {
+    failureHelper("sla . = 3;")
+  }
+
+  test("should fail on missing expression in record assignment") {
+    failureHelper("sla . a = ;")
+  }
+
+  test("should fail on missing first expression in record store") {
+    failureHelper("(* ) . id = 0;")
+  }
+
+  test("should fail on missing id in record store") {
+    failureHelper("(* exp) . = 0;")
+  }
+
+  test("should fail on missing second expression in record store") {
+    failureHelper("( * exp ) . id = ;")
+  }
+}

--- a/src/test/scala/br/unb/cic/tip/parser/TipParserTest.scala.scala
+++ b/src/test/scala/br/unb/cic/tip/parser/TipParserTest.scala.scala
@@ -1,0 +1,166 @@
+package br.unb.cic.tip.parser
+
+import org.scalatest.funsuite.AnyFunSuite
+import br.unb.cic.tip.*
+
+import br.unb.cic.tip.Stmt.*
+import br.unb.cic.tip.Expression.*
+
+class TipParserTest extends AnyFunSuite {
+  test("should parse successfully an empty string") {
+    val result = TipParser.parse("")
+
+    assert(result.get == List())
+  }
+
+  test("should parse example program 1") {
+    val input = """
+        iterate(n) {
+            var f;
+            f = 1;
+            while (n>0) {
+                f = f*n;
+                n = n-1;
+            }
+            return f;
+        }
+    """
+
+    val result = TipParser.parse(input)
+
+    assert(
+      result.get == List(
+        FunDecl(
+          "iterate",
+          List("n"),
+          List("f"),
+          SequenceStmt(
+            AssignmentStmt("f", ConstExp(1)),
+            WhileStmt(
+              GTExp(VariableExp("n"), ConstExp(0)),
+              SequenceStmt(
+                AssignmentStmt(
+                  "f",
+                  MultiExp(VariableExp("f"), VariableExp("n"))
+                ),
+                AssignmentStmt("n", SubExp(VariableExp("n"), ConstExp(1)))
+              )
+            )
+          ),
+          VariableExp("f")
+        )
+      )
+    )
+  }
+
+  test("should parse example program 2") {
+    val input = """
+        recurse(n) {
+            var f;
+            if (n==0) { f=1; }
+            else { f=n*recurse(n-1); }
+            return f;
+        }
+    """
+
+    val result = TipParser.parse(input)
+
+    assert(
+      result.get == List(
+        FunDecl(
+          "recurse",
+          List("n"),
+          List("f"),
+          IfElseStmt(
+            EqExp(VariableExp("n"), ConstExp(0)),
+            AssignmentStmt("f", ConstExp(1)),
+            Some(
+              AssignmentStmt(
+                "f",
+                MultiExp(
+                  VariableExp("n"),
+                  FunctionCallExp(
+                    VariableExp("recurse"),
+                    List(SubExp(VariableExp("n"), ConstExp(1)))
+                  )
+                )
+              )
+            )
+          ),
+          VariableExp("f")
+        )
+      )
+    )
+  }
+
+  test("should parse example program 3") {
+    val input = """
+        foo(p,x) {
+            var f,q;
+            if ((*p)==0) { f=1; }
+            else {
+                q = alloc 0;
+                *q = (*p)-1;
+                f=(*p)*(x(q,x));
+            }
+            return f;
+        }
+
+        main() {
+            var n;
+            n = input;
+            return foo(&n,foo);
+        }
+    """
+
+    val result = TipParser.parse(input)
+
+    assert(
+      result.get == List(
+        FunDecl(
+          "foo",
+          List("p", "x"),
+          List("f", "q"),
+          IfElseStmt(
+            EqExp(BracketExp(LoadExp(VariableExp("p"))), ConstExp(0)),
+            AssignmentStmt("f", ConstExp(1)),
+            Some(
+              SequenceStmt(
+                AssignmentStmt("q", AllocExp(ConstExp(0))),
+                SequenceStmt(
+                  StoreStmt(
+                    VariableExp("q"),
+                    SubExp(BracketExp(LoadExp(VariableExp("p"))), ConstExp(1))
+                  ),
+                  AssignmentStmt(
+                    "f",
+                    MultiExp(
+                      BracketExp(LoadExp(VariableExp("p"))),
+                      BracketExp(
+                        FunctionCallExp(
+                          VariableExp("x"),
+                          List(VariableExp("q"), VariableExp("x"))
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          VariableExp("f")
+        ),
+        FunDecl(
+          "main",
+          List(),
+          List("n"),
+          AssignmentStmt("n", InputExp),
+          FunctionCallExp(
+            VariableExp("foo"),
+            List(LocationExp("n"), VariableExp("foo"))
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
Initial implementation, still needs tests and some fixes. I'm having some difficulty with:
- [X] parsing of indirect function calls. I made it so that all function calls use variable expressions, due to stack overflows when using a naive dependency on expressions as a whole;
  - Direct function calls only use IDs, indirect use all expressions, but VariableExp due to it being impossible to distinguish from plain IDs; 
- [X] some details of TIP that seem somewhat ill defined; some grammar rules (ie. store operation) seem weird
  - I was overcomplicating things
- [x] unsure about rules of precedence on operators, but I assume this isn't much of a problem.
- [x] Implement tests for:
  - [X] Expressions;
  - [X] Statments;
  - [x] Functions;
  - [x] Programs.

 